### PR TITLE
bugfix for packet_handle_std_clone()

### DIFF
--- a/udatapath/packet_handle_std.c
+++ b/udatapath/packet_handle_std.c
@@ -296,7 +296,7 @@ packet_handle_std_create(struct packet *pkt) {
     return handle;
 }
 struct packet_handle_std *
-packet_handle_std_clone(struct packet *pkt, struct packet_handle_std *handle UNUSED) {
+packet_handle_std_clone(struct packet *pkt, struct packet_handle_std *handle) {
     struct packet_handle_std *clone = xmalloc(sizeof(struct packet_handle_std));
 
     clone->pkt = pkt;
@@ -307,6 +307,7 @@ packet_handle_std_clone(struct packet *pkt, struct packet_handle_std *handle UNU
     // TODO Zoltan: if handle->valid, then match could be memcpy'd, and protocol
     //              could be offset
     packet_handle_std_validate(clone);
+    clone->match->metadata = handle->match->metadata;
 
     return clone;
 }

--- a/udatapath/packet_handle_std.c
+++ b/udatapath/packet_handle_std.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2011, TrafficLab, Ericsson Research, Hungary
+ * Copyright (c) 2012, Budapest University of Technology and Economics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +28,7 @@
  *
  *
  * Author: Zoltán Lajos Kis <zoltan.lajos.kis@ericsson.com>
+ * Author: Felicián Németh <nemethf@tmit.bme.hu>
  */
 
 #include <stdlib.h>


### PR DESCRIPTION
The patch is needed because packet_handle_std_validate() keeps the previous value of the metadata.  See packet_handle_std.c:79-83.
